### PR TITLE
Update readme, spacing changes, comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repository is the new home of the previously-named "si-ead-exporter" Archiv
 
 _Origination_
 
-1. <a name="one"></a>Within `<origination>`, sets the value of an agent's `source` attribute from `agent_record_identifers['primary_identifier']['source']`, instead of the ASpace default of `display_name['source']`.
-2. <a name="two"></a>Within `<origination>`, sets the value of an agent's `authfilenumber` attribute from `agent_record_identifers['primary_identifier']['record_identifier']`, instead of the ASpace default `display_name['authority_id']`.
+1. <a name="one"></a>Within `<origination>`, sets the value of an agent's `source` attribute from `agent_record_identifiers['primary_identifier']['source']`, instead of the ASpace default of `display_name['source']`.
+2. <a name="two"></a>Within `<origination>`, sets the value of an agent's `authfilenumber` attribute from `agent_record_identifiers['primary_identifier']['record_identifier']`, instead of the ASpace default `display_name['authority_id']`.
 
 _Extents_
 
@@ -22,8 +22,8 @@ _Control Access Subjects_
 
 _Control Access Linked Agents_
 
-7. <a name="seven"></a>Within `<controlaccess>`, sets the value of an agent's `source` attribute from `agent_record_identifers['primary_identifier']['source']`, instead of the ASpace default of `display_name['source']`.
-8. <a name="eight"></a>Within `<controlaccess>`, sets the value of an agent's `authfilenumber` attribute from `agent_record_identifers['primary_identifier']['record_identifier']`, instead of the ASpace default `display_name['authority_id']`.
+7. <a name="seven"></a>Within `<controlaccess>`, sets the value of an agent's `source` attribute from `agent_record_identifiers['primary_identifier']['source']`, instead of the ASpace default of `display_name['source']`.
+8. <a name="eight"></a>Within `<controlaccess>`, sets the value of an agent's `authfilenumber` attribute from `agent_record_identifiers['primary_identifier']['record_identifier']`, instead of the ASpace default `display_name['authority_id']`.
 
 _External Documents_
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # lassb-ead-exporter
 This repository is the new home of the previously-named "si-ead-exporter" ArchivesSpace plugin.  
+
+## Overrides
+
+### EAD 2002 Export
+
+_Origination_
+
+1. <a name="one"></a>Within `<origination>`, sets the value of an agent's `source` attribute from `agent_record_identifers['primary_identifier']['source']`, instead of the ASpace default of `display_name['source']`.
+2. <a name="two"></a>Within `<origination>`, sets the value of an agent's `authfilenumber` attribute from `agent_record_identifers['primary_identifier']['record_identifier']`, instead of the ASpace default `display_name['authority_id']`.
+
+_Extents_
+
+3. <a name="three"></a>Within `<physdesc>`, adds the `extent_type` to an `<extent>`'s type attribute for EDAN object_type processing.  Removes the ASpace default extent attribute of `altrender='materialtype spaceoccupied'`.
+
+_Control Access Subjects_
+
+4. <a name="four"></a>Within `<controlaccess>`, exports subject records with the term_type `cultural_context` as a `<subject>`, instead of the ASpace default of `<geogname>`.
+5. <a name="five"></a>Within `<controlaccess>`, exports subject records with the term_type `temporal` as a `<subject>`.  ASpace does not export this by default.
+6. <a name="six"></a>Within `<controlaccess>`, adds an `altrender` attribute containing a subject's term type to all subject record exports (no altrender attribute is set by ASpace by default).
+
+_Control Access Linked Agents_
+
+7. <a name="seven"></a>Within `<controlaccess>`, sets the value of an agent's `source` attribute from `agent_record_identifers['primary_identifier']['source']`, instead of the ASpace default of `display_name['source']`.
+8. <a name="eight"></a>Within `<controlaccess>`, sets the value of an agent's `authfilenumber` attribute from `agent_record_identifers['primary_identifier']['record_identifier']`, instead of the ASpace default `display_name['authority_id']`.
+
+_External Documents_
+
+9. <a name="nine"></a>Within `<archdesc>`, exports an additional `<note altrender="external_documents" label="See Also">` note holding a link to an external document.  The note contains an `<extref altrender="online_media">` inside of `<p>` tags, with the extref's `xlink:href` and `xlink:title` attributes populated from the external document record.  External documents are not exported by ASpace by default.
+10. <a name="ten"></a>Within `<c>`, exports an additional `<note altrender="external_documents" label="See Also">` note holding a link to an external document.  The note contains an `<extref altrender="online_media">` inside of `<p>` tags, with the extref's `xlink:href` and `xlink:title` attributes populated from the external document record.  External documents are not exported by ASpace by default.
+
+
+| Line        | ASpace Default (simplified example)                                | SI Override (simplified example)                                      |
+| ----------- | ------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| [1](#one)   | `<persname source="display_name['source']">`                       | `<persname source="primary_identifier['source']">`                    |
+| [2](#two)   | `<persname authfilenumber="display_name['authority_id']">`         | `<persname authfilenumber="primary_identifier['record_identifier']">` |
+| [3](#three) | `<extent altrender="materialtype spaceoccupied">1 Sheets</extent>` | `<extent type="Sheets">1 Sheets</extent>`                             |
+| [4](#four)  | `<geogname>Cultural Context Term</geogname>`                       | `<subject>Cultural Context Term</subject>`                            |
+| [5](#five)  | none                                                               | `<subjec>Temporal term</subject>`                                     |
+| [6](#six)   | `<subject>`                                                        | `<subject altrender="topical">`                                       |
+| [7](#seven) | `<persname source="display_name['source']">`                       | `<persname source="primary_identifier['source']">`                    |
+| [8](#eight) | `<persname authfilenumber="display_name['authority_id']">`         | `<persname authfilenumber="primary_identifier['record_identifier']">` |
+| [9](#nine)  | none                                                               | `<note altrender="external_documents" label="See Also"><p><extref altrender="online_media" xlink:href="location" xlink:title="Title">Title</extref></p></note>` |
+| [10](#ten)  | none                                                               | `<note altrender="external_documents" label="See Also"><p><extref altrender="online_media" xlink:href="location" xlink:title="Title">Title</extref></p></note>` |

--- a/backend/lib/si_ead_extras_serialize.rb
+++ b/backend/lib/si_ead_extras_serialize.rb
@@ -1,6 +1,7 @@
 class SIEADSerialize
 
   def call(data, xml, fragments, context)
+    # MODIFICATION: Add external documents to note within <c>'s (not exported by default).
     if context == :c
       data.external_documents.each do |ext_doc|
         return if ext_doc["publish"] === false && !@include_unpublished
@@ -8,15 +9,13 @@ class SIEADSerialize
         atts['xlink:href'] = ext_doc['location']
         atts['xlink:title'] = ext_doc['title']
         atts['altrender'] = 'online_media'
-      
+
         xml.note ({:label => 'See Also', :altrender => 'external_documents'}) {
             xml.p {xml.extref(atts) { xml.text (ext_doc['title']) }}
           }
       end
 
-      #user defined?
-      #classifications?
-    
+    # MODIFICATION: Add external documents to note within <archdesc> (not exported by default).
     elsif context == :archdesc
       if data.external_documents
         data.external_documents.each do |ext_doc|
@@ -25,14 +24,13 @@ class SIEADSerialize
           atts['xlink:href'] = ext_doc['location']
           atts['xlink:title'] = ext_doc['title']
           atts['altrender'] = 'online_media'
-        
+
           xml.note ({:label => 'See Also', :altrender => 'external_documents'}) {
               xml.p {xml.extref(atts) { xml.text (ext_doc['title']) }}
             }
         end
       end
-
-     
     end
   end
+
 end

--- a/backend/lib/si_export_helpers.rb
+++ b/backend/lib/si_export_helpers.rb
@@ -5,6 +5,8 @@ module ASpaceExport
   module ArchivalObjectDescriptionHelpers
 
     # MODIFICATION: add cultural_context as a subject, rather than geogname, which is ASpace's default.
+    # MODIFICATION: add temporal as a subject (not exported by default).
+    # MODIFICATION: add altrender="term_type".
     def controlaccess_subjects
       unless @controlaccess_subjects
         results = []
@@ -14,17 +16,17 @@ module ASpaceExport
 
           node_name = case subject['terms'][0]['term_type']
                       when 'function'; 'function'
-                      when 'genre_form', 'style_period';  'genreform'
+                      when 'genre_form', 'style_period'; 'genreform'
                       when 'geographic'; 'geogname'
-                      when 'occupation';  'occupation'
-                      when 'topical', 'temporal','cultural_context'; 'subject'
+                      when 'occupation'; 'occupation'
+                      when 'topical', 'temporal', 'cultural_context'; 'subject'
                       when 'uniform_title'; 'title'
                       else; nil
                       end
 
           next unless node_name
 
-          content = subject['terms'].map{|t| t['term']}.join(' -- ')
+          content = subject['terms'].map {|t| t['term']}.join(' -- ')
 
           atts = {}
           atts['source'] = subject['source'] if subject['source']
@@ -86,7 +88,6 @@ module ASpaceExport
 
       @controlaccess_linked_agents
     end
-
 
   end
 end

--- a/backend/model/si_ead_exporter.rb
+++ b/backend/model/si_ead_exporter.rb
@@ -2,78 +2,74 @@
 require 'nokogiri'
 require 'securerandom'
 
-
 class EADSerializer < ASpaceExport::Serializer
-    serializer_for :ead
+  serializer_for :ead
 
-    # MODIFICATION: Add @type for EDAN object_type processing
-    def serialize_extents(obj, xml, fragments)
-      if obj.extents.length
-        obj.extents.each do |e|
-          next if e["publish"] === false && !@include_unpublished
-          audatt = e["publish"] === false ? {:audience => 'internal'} : {}
+  # MODIFICATION: Add @type for EDAN object_type processing
+  def serialize_extents(obj, xml, fragments)
+    if obj.extents.length
+      obj.extents.each do |e|
+        next if e["publish"] === false && !@include_unpublished
+        audatt = e["publish"] === false ? {:audience => 'internal'} : {}
 
-          extent_number_float = e['number'].to_f
-          extent_type = I18n.t('enumerations.extent_extent_type.'+e['extent_type'], :default => e['extent_type'])
+        extent_number_float = e['number'].to_f
+        extent_type = I18n.t('enumerations.extent_extent_type.'+e['extent_type'], :default => e['extent_type'])
 
-
-          xml.physdesc({:altrender => e['portion']}.merge(audatt)) {
-            if e['number'] && e['extent_type'] 
-              xml.extent({:type => extent_type}) {
-                sanitize_mixed_content("#{e['number']} #{extent_type}", xml, fragments)
-              }
-            end
-            if e['container_summary']
-              xml.extent({:altrender => 'carrier'}) {
-                sanitize_mixed_content( e['container_summary'], xml, fragments)
-              }
-            end
-            xml.physfacet { sanitize_mixed_content(e['physical_details'],xml, fragments) } if e['physical_details']
-            xml.dimensions  {   sanitize_mixed_content(e['dimensions'],xml, fragments) }  if e['dimensions']
-          }
-        end
-      end
-    end
-
-    # MODIFICATION: use new agent record identifier field for authfilenumber AND source, rather than agent name authority ID value, which is still ASpace's default even in 3.x, for whatever reason.
-    # Should update this so that the code is modularized, but not right now.
-    def serialize_origination(data, xml, fragments)
-      unless data.creators_and_sources.nil?
-        data.creators_and_sources.each do |link|
-          agent = link['_resolved']
-          published = agent['publish'] === true
-  
-          next if !published && !@include_unpublished
-  
-          link['role'] == 'creator' ? role = link['role'].capitalize : role = link['role']
-          relator = link['relator']
-          sort_name = agent['display_name']['sort_name']
-          rules = agent['display_name']['rules']
-          # NEW, begin
-          source = agent['agent_record_identifiers'].select {|i| i['primary_identifier'] == true}.map {|s| s['source']}.first
-          authfilenumber = agent['agent_record_identifiers'].select {|i| i['primary_identifier'] == true}.map {|ri| ri['record_identifier']}.first
-          # NEW, end
-          node_name = case agent['agent_type']
-                      when 'agent_person'; 'persname'
-                      when 'agent_family'; 'famname'
-                      when 'agent_corporate_entity'; 'corpname'
-                      when 'agent_software'; 'name'
-                      end
-  
-          origination_attrs = {:label => role}
-          origination_attrs[:audience] = 'internal' unless published
-          xml.origination(origination_attrs) {
-            atts = {:role => relator, :source => source, :rules => rules, :authfilenumber => authfilenumber}
-            atts.reject! {|k, v| v.nil?}
-  
-            xml.send(node_name, atts) {
-              sanitize_mixed_content(sort_name, xml, fragments )
+        xml.physdesc({:altrender => e['portion']}.merge(audatt)) {
+          if e['number'] && e['extent_type']
+            xml.extent({:type => extent_type}) {
+              sanitize_mixed_content("#{e['number']} #{extent_type}", xml, fragments)
             }
-          }
-        end
+          end
+          if e['container_summary']
+            xml.extent({:altrender => 'carrier'}) {
+              sanitize_mixed_content( e['container_summary'], xml, fragments)
+            }
+          end
+          xml.physfacet { sanitize_mixed_content(e['physical_details'], xml, fragments) } if e['physical_details']
+          xml.dimensions  { sanitize_mixed_content(e['dimensions'], xml, fragments) } if e['dimensions']
+        }
       end
     end
-  
+  end
+
+  # MODIFICATION: use new agent record identifier field for authfilenumber AND source, rather than agent name authority ID value, which is still ASpace's default even in 3.x, for whatever reason.
+  # Should update this so that the code is modularized, but not right now.
+  def serialize_origination(data, xml, fragments)
+    unless data.creators_and_sources.nil?
+      data.creators_and_sources.each do |link|
+        agent = link['_resolved']
+        published = agent['publish'] === true
+
+        next if !published && !@include_unpublished
+
+        link['role'] == 'creator' ? role = link['role'].capitalize : role = link['role']
+        relator = link['relator']
+        sort_name = agent['display_name']['sort_name']
+        rules = agent['display_name']['rules']
+        # NEW, begin
+        source = agent['agent_record_identifiers'].select {|i| i['primary_identifier'] == true}.map {|s| s['source']}.first
+        authfilenumber = agent['agent_record_identifiers'].select {|i| i['primary_identifier'] == true}.map {|ri| ri['record_identifier']}.first
+        # NEW, end
+        node_name = case agent['agent_type']
+                    when 'agent_person'; 'persname'
+                    when 'agent_family'; 'famname'
+                    when 'agent_corporate_entity'; 'corpname'
+                    when 'agent_software'; 'name'
+                    end
+
+        origination_attrs = {:label => role}
+        origination_attrs[:audience] = 'internal' unless published
+        xml.origination(origination_attrs) {
+          atts = {:role => relator, :source => source, :rules => rules, :authfilenumber => authfilenumber}
+          atts.reject! {|k, v| v.nil?}
+
+          xml.send(node_name, atts) {
+            sanitize_mixed_content(sort_name, xml, fragments )
+          }
+        }
+      end
+    end
+  end
 
 end
-


### PR DESCRIPTION
Expands the existing README to further document the EAD2002 export overrides.  Also, lints files for consistent spacing, indentation, etc.  Finally, adds/expands on existing inline comments for greater clarity.  There are _no functional changes_ to the plugin introduced in this PR.