### PR TITLE
Handle content_warnings plugin steps

### DIFF
--- a/backend/lib/aspace_serializer_overrides.rb
+++ b/backend/lib/aspace_serializer_overrides.rb
@@ -8,7 +8,12 @@ class EADSerializer < ASpaceExport::Serializer
 
     def self.run_serialize_step(data, xml, fragments, context, include_unpublished = false)
       Array(@extra_serialize_steps).each do |step|
-        step.new.call(data, xml, fragments, context, include_unpublished)
+        # Adding in check so as not to break existing plugins missing `include_unpublished`
+        if step.new.method(:call).arity == 4
+          step.new.call(data, xml, fragments, context)
+        else
+          step.new.call(data, xml, fragments, context, include_unpublished)
+        end
       end
     end
 


### PR DESCRIPTION
## Description
Fixes EAD export breaking when `aspace_content_warnings` plugin is enabled.

## Related GitHub Issue
Closes #15 

## Testing
Automated tests pass.

## Screenshot(s):

## Checklist

- [ ] ✔️ Have you assigned at least one reviewer?
Skipping, for hotfix on test where EAD export is currently broken.
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [ ] 🧪 Have you added tests to cover these changes?  If not, why:
N/A
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
