### PR TITLE
Test against ASpace v4.1.0 #20

### DIFF
--- a/.github/workflows/backend_plugin_test.yml
+++ b/.github/workflows/backend_plugin_test.yml
@@ -14,7 +14,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        archivesspace_version: [v3.3.1, v3.4.1, v3.5.1, v4.0.0]
+        archivesspace_version: [v3.3.1, v4.0.0, v4.1.0]
 
     services:
       db:


### PR DESCRIPTION
## Description
Just adds v4.1.0 to the test matrix and, in doing so, confirms this backend-only plugin should work as-is under v4.1.0.

## Related GitHub Issue
Closes #20 

## Testing
Tests pass.

## Screenshot(s):
N/A

## Checklist

- [ ] ✔️ Have you assigned at least one reviewer?
Skipping, no actual code changes.
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
No changes.
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
